### PR TITLE
Fix HTTP cleanup

### DIFF
--- a/shared/src/main/java/me/zyypj/booter/shared/http/client/HttpRequest.kt
+++ b/shared/src/main/java/me/zyypj/booter/shared/http/client/HttpRequest.kt
@@ -62,7 +62,9 @@ class HttpRequest<T> @JvmOverloads constructor(
                 requestMethod = "GET"
                 setRequestProperty("requireSSL", requireSSL.toString())
                 connectTimeout = effectiveTimeout
-                contentType?.takeIf { it.isNotEmpty() }?.let { setRequestProperty("Content-Type", it) }
+                contentType?.takeIf { it.isNotEmpty() }?.let {
+                    setRequestProperty("Content-Type", it)
+                }
                 connect()
             }
 
@@ -75,6 +77,9 @@ class HttpRequest<T> @JvmOverloads constructor(
         } catch (ex: RuntimeException) {
             exception = ex
             false
+        } finally {
+            // Ensure the connection is always released
+            requestConnection?.disconnect()
         }
     }
 


### PR DESCRIPTION
## Summary
- call `disconnect()` in `HttpRequest.execute()` to always close the connection

## Testing
- `./gradlew spotlessCheck`

------
https://chatgpt.com/codex/tasks/task_e_6848b1c816d0832d83b226ca7daf491b